### PR TITLE
clarify output

### DIFF
--- a/find_user_id/find_user_id.py
+++ b/find_user_id/find_user_id.py
@@ -85,7 +85,8 @@ last_login_time = 0
 # Statistics
 checked_count = 0
 found_count = 0
-error_count = 0
+exception_count = 0
+exception_ids = set()       # user IDs whose request raised a network exception
 start_time = 0
 
 # Signal to stop when a valid user ID is found
@@ -153,7 +154,7 @@ def shutdown_with_hit(user_id, response_text):
     print("-" * 60)
     with stats_lock:
         print(f"[DONE] Checked        : {checked_count}")
-        print(f"[DONE] Errors         : {error_count}")
+        print(f"[DONE] Exceptions     : {exception_count}")
     print(f"[DONE] Time to find   : {int(elapsed//60)}m{int(elapsed%60)}s")
     print("=" * 60)
 
@@ -167,7 +168,7 @@ def shutdown_with_hit(user_id, response_text):
 # CHECK A USER ID
 # ------------------------------------------------------------
 def check_user(user_id):
-    global checked_count, found_count, error_count
+    global checked_count, found_count, exception_count
 
     # If a valid ID has already been found by another thread,
     # we no longer perform any requests.
@@ -211,8 +212,13 @@ def check_user(user_id):
                     shutdown_with_hit(user_str, r.text)
 
         except requests.RequestException:
+            # A network exception still counts as "checked": we tried this id
+            # but got no response, so we move on. It is NOT a reliable "not the
+            # one", so we record the id to report it at the end of the scan.
             with stats_lock:
-                error_count += 1
+                checked_count += 1
+                exception_count += 1
+                exception_ids.add(user_id)
 
     time.sleep(0.01)
 
@@ -229,6 +235,7 @@ def progress_reporter(total_users):
 
         with stats_lock:
             current_checked = checked_count
+            current_exceptions = exception_count
 
         now = time.time()
         elapsed = now - start_time
@@ -249,6 +256,7 @@ def progress_reporter(total_users):
         print(
             f"[STATS] checked={current_checked} "
             f"({progress_pct:.2f}%) | "
+            f"exceptions={current_exceptions} | "
             f"rate={rate_recent:.1f}/s (avg {rate_total:.1f}/s) | "
             f"elapsed={int(elapsed//60)}m{int(elapsed%60)}s | "
             f"ETA={eta_h}h{eta_m:02d}m"
@@ -291,6 +299,8 @@ reporter_thread = threading.Thread(
 reporter_thread.start()
 
 submitted = 0
+batch_start = SEARCH_START      # first id of the current (not yet logged) batch
+last_id = SEARCH_START          # last id actually submitted
 with ThreadPoolExecutor(max_workers=THREADS) as executor:
     for user_id in range(SEARCH_START, SEARCH_END):
         # If a hit has been found in the meantime, we stop feeding
@@ -302,9 +312,15 @@ with ThreadPoolExecutor(max_workers=THREADS) as executor:
 
         executor.submit(check_user, user_id)
         submitted += 1
+        last_id = user_id
 
         if submitted % 10000 == 0:
-            print(f"[QUEUE] {submitted}/{total_users} user IDs submitted to the pool")
+            print(f"[QUEUE] user IDs {batch_start} to {user_id} submitted to the pool ({submitted}/{total_users})")
+            batch_start = user_id + 1
+
+    # Show the final partial batch (when the range end is not a multiple of 10000)
+    if batch_start <= last_id:
+        print(f"[QUEUE] user IDs {batch_start} to {last_id} submitted to the pool ({submitted}/{total_users})")
 
 print("=" * 60)
 print("[+] All tasks submitted. Waiting for workers to finish...")
@@ -316,7 +332,13 @@ elapsed_total = time.time() - start_time
 with stats_lock:
     print("=" * 60)
     print("[DONE] Scan finished - NO HIT FOUND on the full range.")
-    print(f"[DONE] Total checked : {checked_count}")
-    print(f"[DONE] Total errors  : {error_count}")
-    print(f"[DONE] Total time    : {int(elapsed_total//3600)}h{int((elapsed_total%3600)//60)}m{int(elapsed_total%60)}s")
+    print(f"[DONE] Total checked    : {checked_count}")
+    print(f"[DONE] Total exceptions : {exception_count}")
+    print(f"[DONE] Total time       : {int(elapsed_total//3600)}h{int((elapsed_total%3600)//60)}m{int(elapsed_total%60)}s")
+    if exception_ids:
+        failed_ids = sorted(exception_ids)
+        print("-" * 60)
+        print(f"[DONE] {len(failed_ids)} user ID(s) raised a network exception and were")
+        print("[DONE] NOT reliably checked. Consider re-scanning these IDs:")
+        print("[DONE] " + ", ".join(str(i) for i in failed_ids))
     print("=" * 60)

--- a/find_user_id/find_user_id_fr.py
+++ b/find_user_id/find_user_id_fr.py
@@ -84,7 +84,8 @@ derniere_connexion = 0
 # Statistiques
 nb_verifies = 0
 nb_trouves = 0
-nb_erreurs = 0
+nb_exceptions = 0
+ids_en_exception = set()       # identifiants dont la requête a levé une exception réseau
 temps_debut = 0
 
 # Signal d'arrêt quand un identifiant valide est trouvé
@@ -152,7 +153,7 @@ def arret_avec_succes(identifiant, reponse):
     print("-" * 60)
     with verrou_stats:
         print(f"[FIN] Vérifiés        : {nb_verifies}")
-        print(f"[FIN] Erreurs         : {nb_erreurs}")
+        print(f"[FIN] Exceptions      : {nb_exceptions}")
     print(f"[FIN] Temps écoulé    : {int(duree//60)}m{int(duree%60)}s")
     print("=" * 60)
 
@@ -165,7 +166,7 @@ def arret_avec_succes(identifiant, reponse):
 # VERIFICATION D'UN IDENTIFIANT
 # ------------------------------------------------------------
 def verifier_utilisateur(id_utilisateur):
-    global nb_verifies, nb_trouves, nb_erreurs
+    global nb_verifies, nb_trouves, nb_exceptions
 
     # Si un identifiant valide a déjà été trouvé par un autre thread,
     # on n'effectue plus aucune requête.
@@ -209,8 +210,14 @@ def verifier_utilisateur(id_utilisateur):
                     arret_avec_succes(identifiant, r.text)
 
         except requests.RequestException:
+            # Une exception réseau compte aussi comme "vérifié" : on a tenté
+            # cet identifiant mais sans réponse, on passe donc au suivant. Ce
+            # n'est PAS un "ce n'est pas le bon" fiable, on note l'identifiant
+            # pour le signaler dans le rapport de fin.
             with verrou_stats:
-                nb_erreurs += 1
+                nb_verifies += 1
+                nb_exceptions += 1
+                ids_en_exception.add(id_utilisateur)
 
     time.sleep(0.01)
 
@@ -227,6 +234,7 @@ def rapport_progression(total_utilisateurs):
 
         with verrou_stats:
             verifies_actuels = nb_verifies
+            exceptions_actuelles = nb_exceptions
 
         maintenant = time.time()
         duree = maintenant - temps_debut
@@ -247,6 +255,7 @@ def rapport_progression(total_utilisateurs):
         print(
             f"[STATS] vérifiés={verifies_actuels} "
             f"({pourcentage:.2f}%) | "
+            f"exceptions={exceptions_actuelles} | "
             f"cadence={cadence_recente:.1f}/s (moy {cadence_totale:.1f}/s) | "
             f"écoulé={int(duree//60)}m{int(duree%60)}s | "
             f"ETA={eta_h}h{eta_m:02d}m"
@@ -289,6 +298,8 @@ thread_rapport = threading.Thread(
 thread_rapport.start()
 
 nb_soumis = 0
+debut_lot = DEBUT_RECHERCHE     # premier id du lot courant (pas encore affiché)
+dernier_id = DEBUT_RECHERCHE    # dernier id réellement soumis
 with ThreadPoolExecutor(max_workers=NB_THREADS) as executor:
     for id_utilisateur in range(DEBUT_RECHERCHE, FIN_RECHERCHE):
         # Si un identifiant valide a été trouvé entre-temps, on arrête
@@ -300,9 +311,15 @@ with ThreadPoolExecutor(max_workers=NB_THREADS) as executor:
 
         executor.submit(verifier_utilisateur, id_utilisateur)
         nb_soumis += 1
+        dernier_id = id_utilisateur
 
         if nb_soumis % 10000 == 0:
-            print(f"[FILE] {nb_soumis}/{total_utilisateurs} identifiants envoyés dans la file")
+            print(f"[FILE] identifiants {debut_lot} à {id_utilisateur} envoyés dans la file d'attente ({nb_soumis}/{total_utilisateurs})")
+            debut_lot = id_utilisateur + 1
+
+    # Affiche le dernier lot partiel (quand la fin n'est pas un multiple de 10 000)
+    if debut_lot <= dernier_id:
+        print(f"[FILE] identifiants {debut_lot} à {dernier_id} envoyés dans la file d'attente ({nb_soumis}/{total_utilisateurs})")
 
 print("=" * 60)
 print("[+] Toutes les tâches ont été soumises. Attente de la fin des workers...")
@@ -314,7 +331,13 @@ duree_totale = time.time() - temps_debut
 with verrou_stats:
     print("=" * 60)
     print("[FIN] Scan terminé - AUCUN IDENTIFIANT TROUVE sur la plage complète.")
-    print(f"[FIN] Total vérifiés : {nb_verifies}")
-    print(f"[FIN] Total erreurs  : {nb_erreurs}")
-    print(f"[FIN] Temps total    : {int(duree_totale//3600)}h{int((duree_totale%3600)//60)}m{int(duree_totale%60)}s")
+    print(f"[FIN] Total vérifiés   : {nb_verifies}")
+    print(f"[FIN] Total exceptions : {nb_exceptions}")
+    print(f"[FIN] Temps total      : {int(duree_totale//3600)}h{int((duree_totale%3600)//60)}m{int(duree_totale%60)}s")
+    if ids_en_exception:
+        ids_echec = sorted(ids_en_exception)
+        print("-" * 60)
+        print(f"[FIN] {len(ids_echec)} identifiant(s) ont provoqué une exception réseau et")
+        print("[FIN] n'ont PAS été vérifiés de façon fiable. Pensez à relancer le scan dessus :")
+        print("[FIN] " + ", ".join(str(i) for i in ids_echec))
     print("=" * 60)


### PR DESCRIPTION
1. the script output did not account for network errors
2.   ```
      > [QUEUE] 9900000/9999999 user IDs submitted to the pool
      > [QUEUE] 9900000/9999999 user IDs submitted to the pool
      ``` 
      being the equivalent to `ids from 9900000 to 9910000 are submitted to the pool`  
      is misleading and have been changed

see https://github.com/jugla/keyatome/issues/42#issuecomment-4578186064 and the answer next to it.